### PR TITLE
Add s3ed-profile-name const to allow for customizing the profile for auth

### DIFF
--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -32,7 +32,13 @@
 (defconst s3ed-streamable-commands
   '("head" "cat" "grep" "tail" "sed" "awk" "cut" "wc" "sort" "tr" "uniq" "lbzcat" "gzcat"))
 
+(defconst s3ed-profile-name "default")
+
 ;; s3 functions
+
+(defun s3ed-get-profile-string ()
+  "Get the string used to authorize the s3 command."
+  (concat "--profile=" s3ed-profile-name))
 
 (defun s3ed-get-transfer-message (src dest async)
   "Get message to display when transferring data from SRC to DEST.  If specified, this will be an ASYNC operation."
@@ -49,13 +55,13 @@
                          (concat (parse-s3-ls-raw-output it) "/")
                        (parse-s3-ls-raw-output it))
                      (split-string (s3ed-shell-command-no-message
-                                    (format "aws s3 ls %s" path) t
+                                    (format "aws s3 ls %s %s" (s3ed-get-profile-string) path) t
                                     (format "%s: Listing files on s3..." s3ed-app-name)) "\n")))))
 
 (defun s3ed-s3-cp (src dest &optional recursive async)
   "Copy s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (format "aws s3 cp %s --sse AES256 %s %s"
-                         (if recursive "--recursive" "") src dest))
+  (let ((command (format "aws s3 cp %s %s --sse AES256 %s %s"
+                         (s3ed-get-profile-string) (if recursive "--recursive" "") src dest))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn
@@ -65,7 +71,7 @@
 
 (defun s3ed-s3-cp-streams (srcs command &optional async)
   "Stream s3 SRCS into COMMAND.  If specified, this will be an ASYNC operation."
-  (let ((command (format "(%s) | %s" (mapconcat 'identity (--map (format "aws s3 cp %s -;" it)
+  (let ((command (format "(%s) | %s" (mapconcat 'identity (--map (format "aws s3 cp %s %s -;" (s3ed-get-profile-string) it)
                                                                  srcs) " ") command)))
     (if async
         (async-shell-command command)
@@ -73,8 +79,8 @@
 
 (defun s3ed-s3-mv (src dest &optional recursive async)
   "Move s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (format "aws s3 mv %s --sse AES256 %s %s"
-                         (if recursive "--recursive" "") src dest))
+  (let ((command (format "aws s3 mv %s %s --sse AES256 %s %s"
+                         (s3ed-get-profile-string) (if recursive "--recursive" "") src dest))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn
@@ -86,7 +92,7 @@
   "Remove file or directory PATH from s3. If specified, this will be a RECURSIVE and/or ASYNC operation."
   (let ((msg (format "%s: Removing data from s3%s..." s3ed-app-name
                      (if async " in the background" "")))
-        (command (format "aws s3 rm %s %s" (if recursive "--recursive" "") path)))
+        (command (format "aws s3 rm %s %s %s" (s3ed-get-profile-string) (if recursive "--recursive" "") path)))
     (if async
         (progn
           (apply 'start-process "s3ed-rm" "*s3ed*" (split-string command))


### PR DESCRIPTION
I use a few different profiles on the AWS CLI, so thought it'd be handy to allow the user to pick which one they were using.

I thought about factoring out the calls to `aws s3 ...` into a function which would automatically add the profile, but decided not to mess with the organization there. Seems to work well enough right now and there aren't that many places where we actually shell out to the CLI.

Tested out locally and it seems to work fine.