### PR TITLE
Customize user profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
-sudo: false
 language: generic
+os: linux
+dist: xenial
 env:
   global:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
-  matrix:
-  - EMACS_VERSION=24.4
-  - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.1
-  # 25.2 is identical to 25.3 except for a critical security bug in
-  # enriched text mode (see Emacs Bug#28350).
-  - EMACS_VERSION=25.3
-  - EMACS_VERSION=26 # emacs-26 branch, built daily
-  - EMACS_VERSION=master # master branch, built daily
+    - GHRAW="https://raw.githubusercontent.com"
+  jobs:
+    - EMACS_VERSION=25.1
+    # 25.2 is identical to 25.3 except for a critical security bug in
+    # enriched text mode (see Emacs Bug#28350).
+    - EMACS_VERSION=25.3
+    - EMACS_VERSION=26.1   # Debian is on this version.
+    - EMACS_VERSION=26.3
+    - EMACS_VERSION=27     # 27.0.90, emacs-27 branch, built daily
+    - EMACS_VERSION=master # 28.0.50, master branch, built daily
   allow_failures:
     - env: EMACS_VERSION=master
 install:
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
   - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
   - export EMACS=/tmp/emacs/bin/emacs
-  - $CURL -O https://raw.githubusercontent.com/magnars/dash.el/master/dash.el
+  - $CURL -O ${GHRAW}/magnars/dash.el/master/dash.el
+  - $CURL -O ${GHRAW}/magnars/s.el/master/s.el
   - $EMACS -Q --batch -L . -f batch-byte-compile dash.el
   - $EMACS --version
 script:

--- a/Makefile
+++ b/Makefile
@@ -8,32 +8,30 @@ export INIT_PACKAGE_EL
 
 s3ed-lint:
 	emacs -Q -batch \
-		 --eval "$${INIT_PACKAGE_EL}"	 \
-		 -l s3ed-util.el		 \
-		 -l s3ed-io.el		 \
-		 -l s3ed-mode.el		 \
-		 -l s3ed.el			 \
-		 -f package-lint-batch-and-exit	 \
+		 --eval "$${INIT_PACKAGE_EL}" \
+		 -l s3ed-util.el \
+		 -l s3ed-io.el \
+		 -l s3ed-mode.el \
+		 -l s3ed.el \
+		 -f package-lint-batch-and-exit \
 		 s3ed.el s3ed-util.el s3ed-io.el s3ed-mode.el s3ed.el test/s3ed-tests.el
 
 s3ed-test:
-	export PATH=${PWD}/test/:$$PATH &&		 \
-		emacs -batch -l ert			 \
-			--eval "$${INIT_PACKAGE_EL}"     \
-			-l s3ed-util.el		 \
-			-l s3ed-io.el		 \
-			-l s3ed-mode.el		 \
-			-l s3ed.el			 \
-			-l test/s3ed-tests.el	 \
+	PATH=${PWD}/test/:$$PATH emacs -batch -l ert \
+			--eval "$${INIT_PACKAGE_EL}" \
+			-l s3ed-util.el \
+			-l s3ed-io.el \
+			-l s3ed-mode.el \
+			-l s3ed.el \
+			-l test/s3ed-tests.el \
 			-f ert-run-tests-batch-and-exit
 
 s3ed-travis-test:
-	export PATH=${PWD}/test/:$$PATH &&		 \
-		${EMACS} -Q --batch -L ${PWD}		 \
-			-l ert				 \
-			-l s3ed-util.el		 \
-			-l s3ed-io.el		 \
-			-l s3ed-mode.el		 \
-			-l s3ed.el			 \
-			-l test/s3ed-tests.el	 \
+	PATH=${PWD}/test/:$$PATH ${EMACS} -Q --batch -L ${PWD} \
+			-l ert \
+			-l s3ed-util.el \
+			-l s3ed-io.el \
+			-l s3ed-mode.el \
+			-l s3ed.el \
+			-l test/s3ed-tests.el \
 			-f ert-run-tests-batch-and-exit

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Shell commands in s3ed dired will be applied by streaming (`aws s3 cp <file> -`)
 
 If you save a file with `s3ed-save-file`, the file is first saved in the s3ed temp dir and then that file is copied up to the requested s3 path.
 
+### Setting the aws profile
+
+The profile that will be used can be set using the interactive
+`s3ed-set-profile` function. You can customize the default profile by
+setting the `s3ed-profile-name` variable.
+
+
 ## Dependencies
 
 - The `aws` command line utility should be on your `PATH`

--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -32,7 +32,13 @@
 (defconst s3ed-streamable-commands
   '("head" "cat" "grep" "tail" "sed" "awk" "cut" "wc" "sort" "tr" "uniq" "lbzcat" "gzcat"))
 
+(defconst s3ed-profile-name "default")
+
 ;; s3 functions
+
+(defun s3ed-get-profile-string ()
+  "Get the string used to authorize the s3 command."
+  (concat "--profile=" s3ed-profile-name))
 
 (defun s3ed-get-transfer-message (src dest async)
   "Get message to display when transferring data from SRC to DEST.  If specified, this will be an ASYNC operation."
@@ -49,13 +55,13 @@
                          (concat (parse-s3-ls-raw-output it) "/")
                        (parse-s3-ls-raw-output it))
                      (split-string (s3ed-shell-command-no-message
-                                    (format "aws s3 ls %s" path) t
+                                    (format "aws s3 ls %s %s" (s3ed-get-profile-string) path) t
                                     (format "%s: Listing files on s3..." s3ed-app-name)) "\n")))))
 
 (defun s3ed-s3-cp (src dest &optional recursive async)
   "Copy s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (format "aws s3 cp %s --sse AES256 %s %s"
-                         (if recursive "--recursive" "") src dest))
+  (let ((command (format "aws s3 cp %s %s --sse AES256 %s %s"
+                         (s3ed-get-profile-string) (if recursive "--recursive" "") src dest))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn
@@ -65,7 +71,7 @@
 
 (defun s3ed-s3-cp-streams (srcs command &optional async)
   "Stream s3 SRCS into COMMAND.  If specified, this will be an ASYNC operation."
-  (let ((command (format "(%s) | %s" (mapconcat 'identity (--map (format "aws s3 cp %s -;" it)
+  (let ((command (format "(%s) | %s" (mapconcat 'identity (--map (format "aws s3 cp %s %s -;" (s3ed-get-profile-string) it)
                                                                  srcs) " ") command)))
     (if async
         (async-shell-command command)
@@ -73,8 +79,8 @@
 
 (defun s3ed-s3-mv (src dest &optional recursive async)
   "Move s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (format "aws s3 mv %s --sse AES256 %s %s"
-                         (if recursive "--recursive" "") src dest))
+  (let ((command (format "aws s3 mv %s %s --sse AES256 %s %s"
+                         (s3ed-get-profile-string) (if recursive "--recursive" "") src dest))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn
@@ -86,7 +92,7 @@
   "Remove file or directory PATH from s3. If specified, this will be a RECURSIVE and/or ASYNC operation."
   (let ((msg (format "%s: Removing data from s3%s..." s3ed-app-name
                      (if async " in the background" "")))
-        (command (format "aws s3 rm %s %s" (if recursive "--recursive" "") path)))
+        (command (format "aws s3 rm %s %s %s" (s3ed-get-profile-string) (if recursive "--recursive" "") path)))
     (if async
         (progn
           (apply 'start-process "s3ed-rm" "*s3ed*" (split-string command))

--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -85,8 +85,8 @@ The given CMD string will be appended."
 
 (defun s3ed-s3-mv (src dest &optional recursive async)
   "Move s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (s3ed-aws-cli (format "mv %s --sse AES256 %s %s"
-                                        (if recursive "--recursive" "") src dest)))
+  (let ((command (s3ed-aws-cli (format "mv %s--sse AES256 %s %s"
+                                        (if recursive "--recursive " "") src dest)))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn
@@ -98,7 +98,7 @@ The given CMD string will be appended."
   "Remove file or directory PATH from s3. If specified, this will be a RECURSIVE and/or ASYNC operation."
   (let ((msg (format "%s: Removing data from s3%s..." s3ed-app-name
                      (if async " in the background" "")))
-        (command (s3ed-aws-cli (format "rm %s %s" (if recursive "--recursive" "") path))))
+        (command (s3ed-aws-cli (format "rm %s%s" (if recursive "--recursive " "") path))))
     (if async
         (progn
           (apply 'start-process "s3ed-rm" "*s3ed*" (split-string command))

--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -44,7 +44,7 @@
 (defun s3ed-aws-cli (cmd)
   "Run the aws cli (s3) command with the configured profile.
 The given CMD string will be appended."
-  (format "aws s3 --profile=%s %s" s3ed-profile-name cmd))
+  (format "aws --profile=%s s3 %s" s3ed-profile-name cmd))
 
 (defun s3ed-get-transfer-message (src dest async)
   "Get message to display when transferring data from SRC to DEST.  If specified, this will be an ASYNC operation."
@@ -66,8 +66,8 @@ The given CMD string will be appended."
 
 (defun s3ed-s3-cp (src dest &optional recursive async)
   "Copy s3 SRC file to DEST.  If specified, this will be a RECURSIVE and/or ASYNC operation."
-  (let ((command (s3ed-aws-cli (format "cp %s --sse AES256 %s %s"
-                                  (if recursive "--recursive" "") src dest)))
+  (let ((command (s3ed-aws-cli (format "cp %s--sse AES256 %s %s"
+                                  (if recursive "--recursive " "") src dest)))
         (msg (s3ed-get-transfer-message src dest async)))
     (if async
         (progn

--- a/s3ed-mode.el
+++ b/s3ed-mode.el
@@ -34,7 +34,7 @@
 
 (defun s3ed-is-active ()
   "Check whether s3ed is active."
-  (and s3ed-mode (s3ed-string-starts-with default-directory s3ed-tmp-s3-dir)))
+  (and s3ed-mode (s-prefix? (get-s3ed-tmp-s3-dir) default-directory)))
 
 (defun s3ed-after-save-hook ()
   "Push change to s3 after save."
@@ -110,7 +110,7 @@ The original function and arguments are available as ORIG-DIRED-DO-COPY and ARGS
       (let* ((current-local-file (dired-get-filename))
              (current-s3-file (s3ed-local-path-to-s3-path current-local-file))
              (dest-file (s3ed-completing-read "" (format "Copy %s to" current-s3-file))))
-        (if (s3ed-string-starts-with dest-file s3ed-s3-uri-scheme)
+        (if (s-prefix? s3ed-s3-uri-scheme dest-file)
             (progn
               (s3ed-s3-cp current-s3-file dest-file
                              (s3ed-is-directory current-local-file) t)

--- a/s3ed-util.el
+++ b/s3ed-util.el
@@ -34,9 +34,10 @@
   (equal major-mode 'dired-mode))
 
 (defun s3ed-shell-command-no-message (cmd &optional ret msg)
-  "Run CMD, inhibiting messages from the Emacs builtin ‘shell-command’.
+  "Run CMD, inhibiting messages from underlying process.
 If 'RET' is not nil, results from CMD will be returned.
-Default messages will be replaced with custom message 'MSG' if it is provided."
+Default messages will be replaced with custom message 'MSG' if it is provided.
+If the error code is greater than 0, an error will be raised."
   (when msg (message msg))
   (let* ((inhibit-message t)
          (program-name (car (s-split " " cmd)))
@@ -47,7 +48,7 @@ Default messages will be replaced with custom message 'MSG' if it is provided."
                                  (buffer-string))))
          (program-exit-code (car program-result))
          (program-output (car (cdr program-result))))
-    (if (> program-exit-code 0) (error program-output)
+    (if (> program-exit-code 0) (error (format "Error running command '%s': %s" cmd program-output))
       (when ret program-output))))
 
 (defun s3ed-completing-read-backspace (cur-base)

--- a/s3ed-util.el
+++ b/s3ed-util.el
@@ -47,10 +47,17 @@
 If 'RET' is not nil, results from CMD will be returned.
 Default messages will be replaced with custom message 'MSG' if it is provided."
   (when msg (message msg))
-  (let ((inhibit-message t))
-    (if ret
-        (shell-command-to-string cmd)
-      (shell-command cmd))))
+  (let* ((inhibit-message t)
+         (program-name (car (s-split " " cmd)))
+         (program-args (cdr (s-split " " cmd)))
+         (program-result (with-temp-buffer
+                           (list (apply #'call-process program-name nil
+                                        (current-buffer) nil program-args)
+                                 (buffer-string))))
+         (program-exit-code (car program-result))
+         (program-output (car (cdr program-result))))
+    (if (> program-exit-code 0) (error program-output)
+      (when ret program-output))))
 
 (defun s3ed-completing-read-backspace (cur-base)
   "If CUR-BASE is at the root, backspace acts normally.

--- a/s3ed-util.el
+++ b/s3ed-util.el
@@ -1,6 +1,7 @@
 ;;; s3ed-util.el --- Various utilities
 
 ;; Author: Matt Usifer <mattusifer@gmail.com>
+;; Package-Requires: ((emacs "25.1") (dash "2.17.0") (s "1.12.0"))
 
 ;; S3ed is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -27,16 +28,6 @@
 (defun s3ed-is-root-s3-path (path)
   "Check if PATH is at the root of s3."
   (equal path s3ed-s3-uri-scheme))
-
-(defun s3ed-string-starts-with (s prefix)
-  "Return non-nil if string S begins with PREFIX."
-      (cond ((>= (length s) (length prefix))
-             (string-equal (substring s 0 (length prefix)) prefix))
-            (t nil)))
-
-(defun s3ed-string-ends-with (s suffix)
-  "Return non-nil if string S ends with SUFFIX."
-  (not (equal nil (string-match (format "%s\\'" suffix) s))))
 
 (defun s3ed-is-dired-active ()
   "True if we are in a dired buffer."
@@ -78,7 +69,7 @@ Otherwise, backspace will go up one directory."
 (defun s3ed-completing-read (base msg)
   "Use ‘completing-read’ to find files in s3 starting at BASE.
 MSG will be displayed to the user at prompt."
-  (if (s3ed-string-starts-with base s3ed-s3-uri-scheme)
+  (if (s-prefix? s3ed-s3-uri-scheme base)
       (let* ((choices (seq-remove (lambda (el) (not el)) (s3ed-s3-ls base)))
              (choice (minibuffer-with-setup-hook
                          (lambda ()

--- a/s3ed.el
+++ b/s3ed.el
@@ -3,7 +3,7 @@
 ;; Author: Matt Usifer <mattusifer@gmail.com>
 ;; Version: 0.2.0
 ;; Keywords: s3 tools
-;; Package-Requires: ((emacs "25.1") (dash "2.17.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.17.0") (s "1.12.0"))
 ;; Homepage: https://github.com/mattusifer/s3ed
 
 ;; S3ed is free software; you can redistribute it and/or modify

--- a/s3ed.el
+++ b/s3ed.el
@@ -1,9 +1,9 @@
 ;;; s3ed.el --- Tramp-like access to s3
 
 ;; Author: Matt Usifer <mattusifer@gmail.com>
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Keywords: s3 tools
-;; Package-Requires: ((emacs "24.4") (seq) (dash))
+;; Package-Requires: ((emacs "25.1") (dash "2.17.0"))
 ;; Homepage: https://github.com/mattusifer/s3ed
 
 ;; S3ed is free software; you can redistribute it and/or modify

--- a/s3ed.el
+++ b/s3ed.el
@@ -71,6 +71,16 @@ Will be a refreshed dired buffer if it is a directory."
       (s3ed-mode)
       (s3ed-save-file))))
 
+(defun s3ed-set-profile ()
+  "Set the configured profile that will be used to access AWS"
+  (interactive)
+  (if s3ed-mode
+      (let* ((target-profile (read-string "S3ed Profile: " s3ed-profile-name)))
+        (setq s3ed-profile-name target-profile))
+    (when (y-or-n-p "S3ed mode is disabled, do you want to enable s3ed? ")
+      (s3ed-mode)
+      (s3ed-set-profile))))
+
 (provide 's3ed)
 
 ;;; s3ed.el ends here

--- a/test/aws
+++ b/test/aws
@@ -5,8 +5,9 @@ import shutil
 import sys
 
 AWS_APP = sys.argv[1]
-AWS_OPERATION = sys.argv[2]
-AWS_ARGS = sys.argv[3:]
+AWS_PROFILE = sys.argv[2]
+AWS_OPERATION = sys.argv[3]
+AWS_ARGS = sys.argv[4:]
 
 BASE_DIR = '/tmp/s3ed-aws-testing'
 

--- a/test/aws
+++ b/test/aws
@@ -7,7 +7,7 @@ import sys
 AWS_APP = sys.argv[1]
 AWS_PROFILE = sys.argv[2]
 AWS_OPERATION = sys.argv[3]
-AWS_ARGS = sys.argv[4:]
+AWS_ARGS = [a for a in sys.argv[4:] if len(a)]
 
 BASE_DIR = '/tmp/s3ed-aws-testing'
 

--- a/test/aws
+++ b/test/aws
@@ -4,8 +4,8 @@ import os.path
 import shutil
 import sys
 
-AWS_APP = sys.argv[1]
-AWS_PROFILE = sys.argv[2]
+AWS_PROFILE = sys.argv[1]
+AWS_APP = sys.argv[2]
 AWS_OPERATION = sys.argv[3]
 AWS_ARGS = [a for a in sys.argv[4:] if len(a)]
 

--- a/test/s3ed-tests.el
+++ b/test/s3ed-tests.el
@@ -12,8 +12,7 @@
     `(let ((,dir (file-name-as-directory (make-temp-file "s3ed-" t))))
        (let ((s3ed-test-directory ,dir))
          ,@body)
-;       (delete-directory ,dir t)
-       )))
+       (delete-directory ,dir t))))
 
 (defmacro s3ed-setup-teardown-aws-test-dir (&rest body)
   (let ((aws-test-dir (make-symbol "aws-test-dir")))

--- a/test/s3ed-tests.el
+++ b/test/s3ed-tests.el
@@ -115,7 +115,6 @@
 (ert-deftest s3ed-is-directory-test ()
   (s3ed-setup-teardown-test-dir
    (let ((directory-name (format "%stest-directory" s3ed-test-directory)))
-     (message directory-name)
      (make-directory directory-name t)
      (should (s3ed-is-directory directory-name)))))
 

--- a/test/s3ed-tests.el
+++ b/test/s3ed-tests.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 's)
 
 (require 's3ed-util)
 
@@ -11,7 +12,8 @@
     `(let ((,dir (file-name-as-directory (make-temp-file "s3ed-" t))))
        (let ((s3ed-test-directory ,dir))
          ,@body)
-       (delete-directory ,dir t))))
+;       (delete-directory ,dir t)
+       )))
 
 (defmacro s3ed-setup-teardown-aws-test-dir (&rest body)
   (let ((aws-test-dir (make-symbol "aws-test-dir")))
@@ -19,14 +21,6 @@
        (when (file-exists-p ,aws-test-dir) (delete-directory ,aws-test-dir t))
        ,@body
        (when (file-exists-p ,aws-test-dir) (delete-directory ,aws-test-dir t)))))
-
-(ert-deftest s3ed-string-starts-with ()
-  (should (s3ed-string-starts-with "string" "s"))
-  (should (not (s3ed-string-starts-with "xstring" "s"))))
-
-(ert-deftest s3ed-string-ends-with ()
-  (should (s3ed-string-ends-with "string" "g"))
-  (should (not (s3ed-string-ends-with "string" "s"))))
 
 (ert-deftest s3ed-is-dired-active ()
   (should (not (s3ed-is-dired-active)))
@@ -68,8 +62,8 @@
   (s3ed-setup-teardown-test-dir
    (let* ((inhibit-message t)
           (s3ed-tmp-s3-dir (substring s3ed-test-directory 0 -1))
-          (s3ed-subdir (format "%s/s3ed/" s3ed-tmp-s3-dir))
-          (s3ed-subdir2 (format "%s/another-bucket/" s3ed-tmp-s3-dir)))
+          (s3ed-subdir (format "%s/s3ed/" (get-s3ed-tmp-s3-dir)))
+          (s3ed-subdir2 (format "%s/another-bucket/" (get-s3ed-tmp-s3-dir))))
      (make-directory s3ed-subdir t)
      (make-directory s3ed-subdir2 t)
      (dired s3ed-subdir) ;; background s3ed buffer
@@ -120,18 +114,19 @@
 
 (ert-deftest s3ed-is-directory-test ()
   (s3ed-setup-teardown-test-dir
-   (let ((directory-name (format "%s/test-directory" s3ed-test-directory)))
+   (let ((directory-name (format "%stest-directory" s3ed-test-directory)))
+     (message directory-name)
      (make-directory directory-name t)
      (should (s3ed-is-directory directory-name)))))
 
 (ert-deftest s3ed-local-path-to-s3-path-test ()
-  (should (equal (s3ed-local-path-to-s3-path (format "%s/local/path" s3ed-tmp-s3-dir))
+  (should (equal (s3ed-local-path-to-s3-path (format "%s/local/path" (get-s3ed-tmp-s3-dir)))
                  "s3://local/path"))
   (should (not (s3ed-local-path-to-s3-path "typo/local/path"))))
 
 (ert-deftest s3ed-s3-path-to-local-path-test ()
   (should (equal (s3ed-s3-path-to-local-path "s3://s3/path")
-                 (format "%s/s3/path" s3ed-tmp-s3-dir)))
+                 (format "%s/s3/path" (get-s3ed-tmp-s3-dir))))
   (should (not (s3ed-s3-path-to-local-path "s4://typo/local/path"))))
 
 (ert-deftest s3ed-parent-directory-test ()


### PR DESCRIPTION
Allow user to customize profiles using `s3ed-set-profile`.

This builds on the open PR #23 to allow customization of the profile. It also includes a change to bubble up errors that arise during shell commands.

Resolves #21 