### PR TITLE
attempt to deal with variable access to buckets

### DIFF
--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -42,6 +42,11 @@
   :type '(string)
   :group 's3ed)
 
+(defcustom s3ed-prefix "s3://"
+  "The default s3 bucket prefix"
+  :type '(string)
+  :group 's3ed)
+
 (defconst s3ed-app-name "s3ed")
 
 (defun get-s3ed-tmp-s3-dir () (format "%s/%s/%s" s3ed-tmp-s3-dir s3ed-app-name s3ed-profile-name))

--- a/s3ed-io.el
+++ b/s3ed-io.el
@@ -42,9 +42,9 @@
   :type '(string)
   :group 's3ed)
 
-(defcustom s3ed-prefix "s3://"
-  "The default s3 bucket prefix"
-  :type '(string)
+(defcustom s3ed-bucket-list '()
+  "Default s3 prefix"
+  :type '(repeat string)
   :group 's3ed)
 
 (defconst s3ed-app-name "s3ed")

--- a/s3ed.el
+++ b/s3ed.el
@@ -38,7 +38,11 @@ Will be a refreshed dired buffer if it is a directory."
   (if s3ed-mode
       (let* ((current-s3-base-path (if (s3ed-is-active)
                                        (s3ed-local-path-to-s3-path default-directory)
-                                     s3ed-prefix))
+                                     (concat "s3://"
+                                             (completing-read "Specify a bucket: s3://"
+                                                              s3ed-bucket-list nil nil
+                                                              nil nil
+                                                              s3ed-bucket-list))))
              (current-s3-file-path (s3ed-completing-read current-s3-base-path
                                                             "Find S3 file"))
              (current-local-file-path (s3ed-s3-path-to-local-path current-s3-file-path)))

--- a/s3ed.el
+++ b/s3ed.el
@@ -38,7 +38,7 @@ Will be a refreshed dired buffer if it is a directory."
   (if s3ed-mode
       (let* ((current-s3-base-path (if (s3ed-is-active)
                                        (s3ed-local-path-to-s3-path default-directory)
-                                     "s3://"))
+                                     s3ed-prefix))
              (current-s3-file-path (s3ed-completing-read current-s3-base-path
                                                             "Find S3 file"))
              (current-local-file-path (s3ed-s3-path-to-local-path current-s3-file-path)))


### PR DESCRIPTION
s3ed always errors out if `s3://` is the only thing in the minibuffer, or if I don't have access to the bucket in question.

This is an attempt (though not pretty) to get around that limitation.  If the current buffer is not an s3ed buffer, then instead of prepping the `s3ed-completing-read` with a bare `s3://`, I've inserted a `completing-read` to set `current-s3-base-path` from choices from `s3ed-bucket-list`.

Another way to deal with this is to change `s3ed-completing-read` to catch the "AccessDenied" errors.